### PR TITLE
Adds the decoding of the "locked" field of msr

### DIFF
--- a/inc/raplcap.h
+++ b/inc/raplcap.h
@@ -84,6 +84,16 @@ uint32_t raplcap_get_num_sockets(const raplcap* rc);
 int raplcap_is_zone_supported(const raplcap* rc, uint32_t socket, raplcap_zone zone);
 
 /**
+ * Check if a zone is locked.
+ *
+ * @param rc
+ * @param socket
+ * @param zone
+ * @return 0 if locked, 1 if locked, a negative value on error
+ */
+int raplcap_is_zone_locked(const raplcap* rc, uint32_t socket, raplcap_zone zone);
+
+/**
  * Check if a zone is enabled.
  * Constraints can technically be enabled/disabled separately, but for simplicity and compatibility with lower-level
  * RAPL interfaces, we define a zone to be enabled only if all of its constraints are enabled (disabled otherwise).

--- a/msr/raplcap-msr-common.c
+++ b/msr/raplcap-msr-common.c
@@ -31,6 +31,8 @@
 #define CL_MASK   0x1
 #define CL1_SHIFT 16
 #define CL2_SHIFT 48
+#define LCK_MASK  0x1
+#define LCK_SHIFT(ctx, zone) (ctx->cfg[zone].lck_shift)
 #define EY_MASK   0xFFFFFFFF
 #define EY_SHIFT  0
 
@@ -208,36 +210,37 @@ static uint64_t to_msr_tw_atom_airmont(double seconds, double time_units) {
   return bits;
 }
 
-#define CFG_STATIC_INIT(ttw, ftw, tpl, fpl, c) { \
+#define CFG_STATIC_INIT(ttw, ftw, tpl, fpl, c, ls) {   \
   .to_msr_tw = ttw, \
   .from_msr_tw = ftw, \
   .to_msr_pl = tpl, \
   .from_msr_pl = fpl, \
-  .constraints = c }
+  .constraints = c, \
+  .lck_shift=ls }
 
 static const raplcap_msr_zone_cfg CFG_DEFAULT[RAPLCAP_NZONES] = {
-  CFG_STATIC_INIT(to_msr_tw_default, from_msr_tw_default, to_msr_pl_default, from_msr_pl_default, 2), // PACKAGE
-  CFG_STATIC_INIT(to_msr_tw_default, from_msr_tw_default, to_msr_pl_default, from_msr_pl_default, 1), // CORE
-  CFG_STATIC_INIT(to_msr_tw_default, from_msr_tw_default, to_msr_pl_default, from_msr_pl_default, 1), // UNCORE
-  CFG_STATIC_INIT(to_msr_tw_default, from_msr_tw_default, to_msr_pl_default, from_msr_pl_default, 1), // DRAM
-  CFG_STATIC_INIT(to_msr_tw_default, from_msr_tw_default, to_msr_pl_default, from_msr_pl_default, 2)  // PSYS
+  CFG_STATIC_INIT(to_msr_tw_default, from_msr_tw_default, to_msr_pl_default, from_msr_pl_default, 2, 63), // PACKAGE
+  CFG_STATIC_INIT(to_msr_tw_default, from_msr_tw_default, to_msr_pl_default, from_msr_pl_default, 1, 31), // CORE
+  CFG_STATIC_INIT(to_msr_tw_default, from_msr_tw_default, to_msr_pl_default, from_msr_pl_default, 1, 31), // UNCORE
+  CFG_STATIC_INIT(to_msr_tw_default, from_msr_tw_default, to_msr_pl_default, from_msr_pl_default, 1, 31), // DRAM
+  CFG_STATIC_INIT(to_msr_tw_default, from_msr_tw_default, to_msr_pl_default, from_msr_pl_default, 2, 63)  // PSYS
 };
 
 static const raplcap_msr_zone_cfg CFG_ATOM[RAPLCAP_NZONES] = {
-  CFG_STATIC_INIT(to_msr_tw_atom, from_msr_tw_atom, to_msr_pl_default, from_msr_pl_default, 1), // PACKAGE
-  CFG_STATIC_INIT(to_msr_tw_atom, from_msr_tw_atom, to_msr_pl_default, from_msr_pl_default, 1), // CORE
-  CFG_STATIC_INIT(to_msr_tw_atom, from_msr_tw_atom, to_msr_pl_default, from_msr_pl_default, 1), // UNCORE
-  CFG_STATIC_INIT(to_msr_tw_atom, from_msr_tw_atom, to_msr_pl_default, from_msr_pl_default, 1), // DRAM
-  CFG_STATIC_INIT(to_msr_tw_atom, from_msr_tw_atom, to_msr_pl_default, from_msr_pl_default, 2), // PSYS
+  CFG_STATIC_INIT(to_msr_tw_atom, from_msr_tw_atom, to_msr_pl_default, from_msr_pl_default, 1, 63), // PACKAGE
+  CFG_STATIC_INIT(to_msr_tw_atom, from_msr_tw_atom, to_msr_pl_default, from_msr_pl_default, 1, 31), // CORE
+  CFG_STATIC_INIT(to_msr_tw_atom, from_msr_tw_atom, to_msr_pl_default, from_msr_pl_default, 1, 31), // UNCORE
+  CFG_STATIC_INIT(to_msr_tw_atom, from_msr_tw_atom, to_msr_pl_default, from_msr_pl_default, 1, 31), // DRAM
+  CFG_STATIC_INIT(to_msr_tw_atom, from_msr_tw_atom, to_msr_pl_default, from_msr_pl_default, 2, 63), // PSYS
 };
 
 // only the CORE time window is different from other ATOM CPUs
 static const raplcap_msr_zone_cfg CFG_ATOM_AIRMONT[RAPLCAP_NZONES] = {
-  CFG_STATIC_INIT(to_msr_tw_atom, from_msr_tw_atom, to_msr_pl_default, from_msr_pl_default, 1), // PACKAGE
-  CFG_STATIC_INIT(to_msr_tw_atom_airmont, from_msr_tw_atom_airmont, to_msr_pl_default, from_msr_pl_default, 1), // CORE
-  CFG_STATIC_INIT(to_msr_tw_atom, from_msr_tw_atom, to_msr_pl_default, from_msr_pl_default, 1), // UNCORE
-  CFG_STATIC_INIT(to_msr_tw_atom, from_msr_tw_atom, to_msr_pl_default, from_msr_pl_default, 1), // DRAM
-  CFG_STATIC_INIT(to_msr_tw_atom, from_msr_tw_atom, to_msr_pl_default, from_msr_pl_default, 2), // PSYS
+  CFG_STATIC_INIT(to_msr_tw_atom, from_msr_tw_atom, to_msr_pl_default, from_msr_pl_default, 1, 63), // PACKAGE
+  CFG_STATIC_INIT(to_msr_tw_atom_airmont, from_msr_tw_atom_airmont, to_msr_pl_default, from_msr_pl_default, 1, 31), // CORE
+  CFG_STATIC_INIT(to_msr_tw_atom, from_msr_tw_atom, to_msr_pl_default, from_msr_pl_default, 1, 31), // UNCORE
+  CFG_STATIC_INIT(to_msr_tw_atom, from_msr_tw_atom, to_msr_pl_default, from_msr_pl_default, 1, 31), // DRAM
+  CFG_STATIC_INIT(to_msr_tw_atom, from_msr_tw_atom, to_msr_pl_default, from_msr_pl_default, 2, 63), // PSYS
 };
 
 uint32_t msr_get_supported_cpu_model(void) {
@@ -341,6 +344,13 @@ static uint64_t replace_bits(uint64_t msrval, uint64_t data, uint8_t first, uint
   assert(last < 64);
   const uint64_t mask = (((uint64_t) 1 << (last - first + 1)) - 1) << first;
   return (msrval & ~mask) | ((data << first) & mask);
+}
+
+int msr_is_zone_locked(const raplcap_msr_ctx* ctx, raplcap_zone zone, uint64_t msrval) {
+  assert(ctx != NULL);
+  const int ret = ((msrval >> LCK_SHIFT(ctx, zone)) & LCK_MASK) == 0x1;
+  raplcap_log(DEBUG, "msr_is_zone_locked: zone=%d, locked=%d\n", zone, ret);
+  return ret;
 }
 
 int msr_is_zone_enabled(const raplcap_msr_ctx* ctx, raplcap_zone zone, uint64_t msrval) {

--- a/msr/raplcap-msr-common.h
+++ b/msr/raplcap-msr-common.h
@@ -38,6 +38,7 @@ typedef struct raplcap_msr_zone_cfg {
   fn_to_msr* to_msr_pl;
   fn_from_msr* from_msr_pl;
   uint8_t constraints;
+  uint8_t lck_shift;
 } raplcap_msr_zone_cfg;
 
 typedef struct raplcap_msr_ctx {
@@ -58,6 +59,11 @@ uint32_t msr_get_supported_cpu_model(void);
  * Populate the context.
  */
 void msr_get_context(raplcap_msr_ctx* ctx, uint32_t cpu_model, uint64_t units_msrval);
+
+/**
+ * Parse msrval to determine if zone is locked.
+ */
+int msr_is_zone_locked(const raplcap_msr_ctx* ctx, raplcap_zone zone, uint64_t msrval);
 
 /**
  * Parse msrval to determine if zone is enabled.

--- a/msr/raplcap-msr.c
+++ b/msr/raplcap-msr.c
@@ -369,6 +369,22 @@ int raplcap_is_zone_enabled(const raplcap* rc, uint32_t socket, raplcap_zone zon
   return ret;
 }
 
+int raplcap_is_zone_locked(const raplcap* rc, uint32_t socket, raplcap_zone zone) {
+  uint64_t msrval;
+  int ret;
+  const raplcap_msr* state = get_state(socket, rc);
+  const off_t msr = zone_to_msr_offset(zone, ZONE_OFFSETS_PL);
+  raplcap_log(DEBUG, "raplcap_is_zone_locked: socket=%"PRIu32", zone=%d\n", socket, zone);
+  if (state == NULL || msr < 0 || read_msr_by_offset(state->fds[socket], msr, &msrval, 0)) {
+    return -1;
+  }
+  ret = msr_is_zone_locked(&state->ctx, zone, msrval);
+  if (ret) {
+    raplcap_log(INFO, "Zone is locked\n");
+  }
+  return ret;
+}
+
 int raplcap_is_zone_supported(const raplcap* rc, uint32_t socket, raplcap_zone zone) {
   uint64_t msrval;
   const raplcap_msr* state = get_state(socket, rc);

--- a/rapl-configure/rapl-configure.c
+++ b/rapl-configure/rapl-configure.c
@@ -71,11 +71,13 @@ static void print_usage(int exit_code) {
 }
 
 static void print_limits(int enabled,
+                         int locked,
                          double watts_long, double seconds_long,
                          double watts_short, double seconds_short,
                          double joules, double joules_max) {
   // Note: simply using %f (6 decimal places) doesn't provide sufficient precision
   const char* en = enabled < 0 ? "unknown" : (enabled ? "true" : "false");
+  const char* lck = locked < 0 ? "unknown" : (locked ? "true" : "false");
   // time window can never be 0, so if it's > 0, the short term constraint exists
   if (seconds_short > 0) {
     printf("%13s: %s\n", "enabled", en);
@@ -89,6 +91,7 @@ static void print_limits(int enabled,
     if (joules_max >= 0) {
       printf("%13s: %.12f\n", "joules_max", joules_max);
     }
+    printf("%13s: %s\n", "locked", lck);
   } else {
     printf("%7s: %s\n", "enabled", en);
     printf("%7s: %.12f\n", "watts", watts_long);
@@ -99,6 +102,7 @@ static void print_limits(int enabled,
     if (joules_max >= 0) {
       printf("%7s: %.12f\n", "joules_max", joules_max);
     }
+    printf("%7s: %s\n", "locked", lck);
   }
 }
 
@@ -155,6 +159,10 @@ static int get_limits(unsigned int socket, raplcap_zone zone) {
   if (enabled < 0) {
     print_error_continue("Failed to determine if zone is enabled");
   }
+  int locked = raplcap_is_zone_locked(NULL, socket, zone);
+  if (enabled < 0) {
+    print_error_continue("Failed to determine if zone is locked");
+  }
   if ((ret = raplcap_get_limits(NULL, socket, zone, &ll, &ls))) {
     perror("Failed to get limits");
     return ret;
@@ -162,7 +170,7 @@ static int get_limits(unsigned int socket, raplcap_zone zone) {
   // we'll consider energy counter information to be optional
   joules = raplcap_get_energy_counter(NULL, socket, zone);
   joules_max = raplcap_get_energy_counter_max(NULL, socket, zone);
-  print_limits(enabled, ll.watts, ll.seconds, ls.watts, ls.seconds, joules, joules_max);
+  print_limits(enabled, locked, ll.watts, ll.seconds, ls.watts, ls.seconds, joules, joules_max);
   return ret;
 }
 


### PR DESCRIPTION
Adds the decoding of the "locked" field of the msr register, helping the user to understand why these settings are not taken into account.