### PR TITLE
msr: add support for ATOM_SILVERMONT_D (model 0x4D)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+* [msr] Support for Atom Silvermont micro server ("Avoton" / "Rangeley"), Model 0x4D
+
 ### Changed
 
 * Changes based on previously deprecated behavior:

--- a/msr/raplcap-cpuid.c
+++ b/msr/raplcap-cpuid.c
@@ -100,6 +100,7 @@ int cpuid_is_cpu_supported(uint32_t family, uint32_t model) {
       //
       case CPUID_MODEL_ATOM_SILVERMONT:
       case CPUID_MODEL_ATOM_SILVERMONT_MID:
+      case CPUID_MODEL_ATOM_SILVERMONT_D:
       case CPUID_MODEL_ATOM_AIRMONT:
       case CPUID_MODEL_ATOM_AIRMONT_MID:
       case CPUID_MODEL_ATOM_GOLDMONT:

--- a/msr/raplcap-cpuid.h
+++ b/msr/raplcap-cpuid.h
@@ -57,9 +57,8 @@ extern "C" {
 
 #define CPUID_MODEL_ATOM_SILVERMONT     0x37 // Bay Trail, Valleyview
 #define CPUID_MODEL_ATOM_SILVERMONT_MID 0x4A // Merriefield
-// "ATOM_SILVERMONT_X" is specified in, but not used by, the Linux kernel
-// Disabled ATOM_SILVERMONT_X b/c it's documentation is strange; no use supporting an apparently non-existent CPU
-// #define CPUID_MODEL_ATOM_SILVERMONT_X  0x4D // Avaton, Rangeley
+// "ATOM_SILVERMONT_D" not supported by Linux kernel powercap interface...
+#define CPUID_MODEL_ATOM_SILVERMONT_D   0x4D // Avoton, Rangeley
 #define CPUID_MODEL_ATOM_AIRMONT        0x4C // Cherry Trail, Braswell
 #define CPUID_MODEL_ATOM_AIRMONT_MID    0x5A // Moorefield
 // "SoFIA" does not appear to have Linux kernel support

--- a/msr/raplcap-msr-common.c
+++ b/msr/raplcap-msr-common.c
@@ -356,6 +356,13 @@ void msr_get_context(raplcap_msr_ctx* ctx, uint32_t cpu_model, uint64_t units_ms
       ctx->time_units = from_msr_tu_default(units_msrval);
       ctx->cfg = CFG_ATOM;
       break;
+    case CPUID_MODEL_ATOM_SILVERMONT_D:
+      ctx->power_units = from_msr_pu_atom(units_msrval);
+      ctx->energy_units = from_msr_eu_atom(units_msrval);
+      ctx->energy_units_dram = ctx->energy_units;
+      ctx->time_units = from_msr_tu_default(units_msrval);
+      ctx->cfg = CFG_DEFAULT;
+      break;
     //----
     case CPUID_MODEL_ATOM_AIRMONT:
       ctx->power_units = from_msr_pu_atom(units_msrval);

--- a/msr/tools/sdm_helper.py
+++ b/msr/tools/sdm_helper.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
              MSR_PKG_ENERGY_STATUS: PKG_DEFAULT,
              MSR_PP0_ENERGY_STATUS: PP0_DEFAULT}
     TBL_9 = {}
-    TBL_10 = {MSR_RAPL_POWER_UNIT: "Table 2-10 (Same as 2-8)",
+    TBL_10 = {MSR_RAPL_POWER_UNIT: "Table 2-10",
               MSR_PKG_POWER_LIMIT: PKG_DEFAULT,
               MSR_PKG_ENERGY_STATUS: PKG_DEFAULT}
     TBL_11 = {MSR_PP0_POWER_LIMIT: "Table 2-11"}
@@ -103,8 +103,8 @@ if __name__ == "__main__":
     ATOM_SILVERMONT.print_line()
     ATOM_SILVERMONT_MID = CPU("0x4A", "ATOM_SILVERMONT_MID", [TBL_6, TBL_7, TBL_8])
     ATOM_SILVERMONT_MID.print_line()
-    ATOM_SILVERMONT_X = CPU("0x4D", "ATOM_SILVERMONT_X", [TBL_6, TBL_7, TBL_10])
-    ATOM_SILVERMONT_X.print_line()
+    ATOM_SILVERMONT_D = CPU("0x4D", "ATOM_SILVERMONT_D", [TBL_6, TBL_7, TBL_10])
+    ATOM_SILVERMONT_D.print_line()
     ATOM_AIRMONT_MID = CPU("0x5A", "ATOM_AIRMONT_MID", [TBL_6, TBL_7, TBL_8])
     ATOM_AIRMONT_MID.print_line()
     ATOM_SOFIA = CPU("0x5D", "ATOM_SOFIA", [TBL_6, TBL_7, TBL_8])


### PR DESCRIPTION
The DComp Testbed has a Silicom RCC-VE network board with an Intel Atom
C2558 processor. It seems we can read RAPL settings, but not set them on
this particular platform, even though the zones are not locked (PACKAGE
and CORE MSR fields simply won't update).
This CPU line is fairly old and for some reason not actually supported by
the Linux kernel's Intel RAPL powercap driver. Maybe the inability to set
constraint values is related.